### PR TITLE
Add built-in zero-ceremony testing harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,41 @@ migrations/         # SQLite-tracked migration files
 - `tiny::set()` / `tiny::get()` / `tiny::data()` — global data bag
 - `tiny::helpers()` / `tiny::registerHelper()` — load or register helpers
 
+## Testing
+
+Tiny has a built-in, zero-ceremony testing harness — no PHPUnit, no bootstrap scripts, no mock libraries. Test files are plain PHP scripts run from the command line.
+
+- **`tiny::swap('db', $fake)`** — inject a mock/stub singleton in test env (`db`, `cache`, `clickhouse`).
+- **`tiny::test('users')`** — load a controller in test env and return its instance.
+- **`TinyTestResponse`** — capture-only response returned by `tiny::response()` in test mode; records `redirectUrl`, `renderedView`, `renderParams`, `output`, `status`, `contentType`.
+- **`TinyTestExit`** — exception thrown by terminating response methods (`redirect`, `render`, `send`, etc.) in test mode. Always catch it in tests.
+- **Auto `:memory:` SQLite** — when `ENV=test` + `DB_TYPE=sqlite` with no file specified, Tiny auto-connects to `:memory:`.
+
+**Test pattern:**
+
+```php
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+// Optionally swap the DB
+tiny::swap('db', new FakeDB());
+
+// Setup request globals
+$_POST = ['name' => 'Ran'];
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+// Load controller and call method
+$ctrl = tiny::test('users');
+$response = tiny::response();
+
+try {
+    $ctrl->post(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->redirectUrl === '/users');
+echo "PASS\n";
+```
+
 ## When Modifying Code
 
 1. Match existing code style (PHP 8.3 features, `declare(strict_types=1)`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,7 @@ migrations/         # SQLite-tracked migration files
 
 Tiny has a built-in, zero-ceremony testing harness — no PHPUnit, no bootstrap scripts, no mock libraries. Test files are plain PHP scripts run from the command line.
 
-- **`tiny::swap('db', $fake)`** — inject a mock/stub singleton in test env (`db`, `cache`, `clickhouse`).
-- **`tiny::test('users')`** — load a controller in test env and return its instance.
-- **`TinyTestResponse`** — capture-only response returned by `tiny::response()` in test mode; records `redirectUrl`, `renderedView`, `renderParams`, `output`, `status`, `contentType`.
-- **`TinyTestExit`** — exception thrown by terminating response methods (`redirect`, `render`, `send`, etc.) in test mode. Always catch it in tests.
-- **Auto `:memory:` SQLite** — when `ENV=test` + `DB_TYPE=sqlite` with no file specified, Tiny auto-connects to `:memory:`.
+**Setup:** Create `.env.test` with `ENV=test`, `DB_TYPE=sqlite`, and `TINY_CACHE_DISABLED=true`. Tiny auto-connects to `:memory:` SQLite and disables caching automatically.
 
 **Test pattern:**
 
@@ -76,10 +72,10 @@ Tiny has a built-in, zero-ceremony testing harness — no PHPUnit, no bootstrap 
 $_SERVER['ENV'] = 'test';
 require __DIR__ . '/../../tiny/tiny.php';
 
-// Optionally swap the DB
-tiny::swap('db', new FakeDB());
+// Seed fresh :memory: database
+tiny::db()->execute("CREATE TABLE users (...)");
 
-// Setup request globals
+// Simulate request
 $_POST = ['name' => 'Ran'];
 $_SERVER['REQUEST_METHOD'] = 'POST';
 
@@ -94,6 +90,8 @@ try {
 assert($response->redirectUrl === '/users');
 echo "PASS\n";
 ```
+
+**Mocking with `tiny::swap()`** — for unit-style isolation, replace singletons (`db`, `cache`, `clickhouse`) with fakes. Only works in test env.
 
 ## When Modifying Code
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,74 @@ See [`docs/extensions/scheduler.md`](docs/extensions/scheduler.md) for the full 
 
 ---
 
+## Testing
+
+Tiny ships with a built-in, zero-ceremony testing harness. No PHPUnit XML, no bootstrap scripts, no mock libraries — just PHP files you run from the command line.
+
+**Three test-friendly primitives:**
+
+- **`tiny::swap()`** — inject mock/stub singletons (`db`, `cache`, `clickhouse`) in test mode
+- **`tiny::test()`** — load a controller in test mode (returns the instance, no HTTP needed)
+- **`TinyTestResponse`** — a capture-only response returned by `tiny::response()` in test mode; records redirect URLs, rendered views, JSON output, and status codes instead of terminating the script
+- **Auto `:memory:` SQLite** — when `ENV=test` and `DB_TYPE=sqlite` with no explicit file, Tiny auto-connects to an in-memory database
+
+**Example test file** — `tests/users/create.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+// Seed a fresh :memory: database
+tiny::db()->execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
+
+// Setup POST data
+$_POST = ['name' => 'Ran'];
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+// Load controller and invoke
+$ctrl = tiny::test('users');
+$response = tiny::response(); // TinyTestResponse
+
+try {
+    $ctrl->post(tiny::request(), $response);
+} catch (TinyTestExit $e) {
+    // Redirects, renders, and sends throw this in test mode — capture the state
+}
+
+// Assert
+assert($response->redirectUrl === '/users');
+assert(tiny::db()->getOne('users', "name = 'Ran'")['name'] === 'Ran');
+
+echo "PASS\n";
+```
+
+**Swap the database for a stub:**
+
+```php
+class FakeDB extends DB
+{
+    public array $inserted = [];
+    public function insert(string $table, array $data): mixed
+    {
+        $this->inserted[] = $data;
+        return 1;
+    }
+}
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+$fake = new FakeDB();
+tiny::swap('db', $fake);
+```
+
+See [`docs/core-concepts/testing.md`](docs/core-concepts/testing.md) for the full reference.
+
+---
+
 ## Deployment
 
 For production, only the `html/` directory should be web-exposed. Everything else (`tiny/`, `app/`, `vendor/`, `.env.prod`) lives one directory up.
@@ -470,7 +538,7 @@ class CreateUsersTable
 Full documentation lives in [`docs/`](docs/):
 
 - **Getting started:** [overview](docs/getting-started/readme.md), [configuration](docs/getting-started/configuration.md), [runtime modes](docs/getting-started/runtime-modes.md), [git deploy](docs/getting-started/git-deploy.md)
-- **Core concepts:** [MVC](docs/core-concepts/mvc.md), [routing](docs/core-concepts/routing.md), [controllers](docs/core-concepts/controllers.md), [request & response](docs/core-concepts/request-response.md), [views](docs/core-concepts/views.md), [models](docs/core-concepts/models.md), [database](docs/core-concepts/database.md), [middleware](docs/core-concepts/middleware.md), [HTMX](docs/core-concepts/htmx.md)
+- **Core concepts:** [MVC](docs/core-concepts/mvc.md), [routing](docs/core-concepts/routing.md), [controllers](docs/core-concepts/controllers.md), [request & response](docs/core-concepts/request-response.md), [views](docs/core-concepts/views.md), [models](docs/core-concepts/models.md), [database](docs/core-concepts/database.md), [middleware](docs/core-concepts/middleware.md), [HTMX](docs/core-concepts/htmx.md), [testing](docs/core-concepts/testing.md)
 - **Extensions:** [cache](docs/extensions/cache.md), [components](docs/extensions/components.md), [cookie](docs/extensions/cookie.md), [CMS](docs/extensions/cms.md), [CSRF](docs/extensions/csrf.md), [database](docs/extensions/database.md), [debugger](docs/extensions/debugger.md), [flash](docs/extensions/flash.md), [HTTP](docs/extensions/http.md), [layout](docs/extensions/layout.md), [migrations](docs/extensions/migrations.md), [scheduler](docs/extensions/scheduler.md), [SSE](docs/extensions/sse.md), [ClickHouse](docs/extensions/clickhouse.md), [Swoole](docs/extensions/swoole.md)
 - **Helpers:** [catalog & custom helpers](docs/helpers/readme.md)
 - **Examples:** [TODO app](docs/examples/todo-app.md), [API](docs/examples/api.md), [chat (SSE)](docs/examples/chat.md), [file upload](docs/examples/file-upload.md), [user management](docs/examples/user-management.md)

--- a/README.md
+++ b/README.md
@@ -416,14 +416,17 @@ See [`docs/extensions/scheduler.md`](docs/extensions/scheduler.md) for the full 
 
 Tiny ships with a built-in, zero-ceremony testing harness. No PHPUnit XML, no bootstrap scripts, no mock libraries — just PHP files you run from the command line.
 
-**Three test-friendly primitives:**
+**Setup: create `.env.test`**
 
-- **`tiny::swap()`** — inject mock/stub singletons (`db`, `cache`, `clickhouse`) in test mode
-- **`tiny::test()`** — load a controller in test mode (returns the instance, no HTTP needed)
-- **`TinyTestResponse`** — a capture-only response returned by `tiny::response()` in test mode; records redirect URLs, rendered views, JSON output, and status codes instead of terminating the script
-- **Auto `:memory:` SQLite** — when `ENV=test` and `DB_TYPE=sqlite` with no explicit file, Tiny auto-connects to an in-memory database
+```env
+ENV=test
+DB_TYPE=sqlite
+TINY_CACHE_DISABLED=true
+```
 
-**Example test file** — `tests/users/create.php`:
+When `ENV=test` + `DB_TYPE=sqlite` with no `DB_SQLITE_FILE`, Tiny auto-connects to `:memory:` — a fresh in-memory database for every test run. `TINY_CACHE_DISABLED=true` keeps tests deterministic by preventing cache pollution between runs.
+
+**Test a controller** — `tests/users/create.php`:
 
 ```php
 <?php
@@ -435,7 +438,7 @@ require __DIR__ . '/../../tiny/tiny.php';
 // Seed a fresh :memory: database
 tiny::db()->execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
 
-// Setup POST data
+// Simulate POST request
 $_POST = ['name' => 'Ran'];
 $_SERVER['REQUEST_METHOD'] = 'POST';
 
@@ -446,7 +449,7 @@ $response = tiny::response(); // TinyTestResponse
 try {
     $ctrl->post(tiny::request(), $response);
 } catch (TinyTestExit $e) {
-    // Redirects, renders, and sends throw this in test mode — capture the state
+    // Terminating methods throw this in test mode — capture the state
 }
 
 // Assert
@@ -456,7 +459,13 @@ assert(tiny::db()->getOne('users', "name = 'Ran'")['name'] === 'Ran');
 echo "PASS\n";
 ```
 
-**Swap the database for a stub:**
+Run it:
+
+```bash
+php tests/users/create.php
+```
+
+**Mocking with `tiny::swap()`** — for unit-style isolation, replace the real DB with a fake:
 
 ```php
 class FakeDB extends DB
@@ -469,11 +478,7 @@ class FakeDB extends DB
     }
 }
 
-$_SERVER['ENV'] = 'test';
-require __DIR__ . '/../../tiny/tiny.php';
-
-$fake = new FakeDB();
-tiny::swap('db', $fake);
+tiny::swap('db', new FakeDB());
 ```
 
 See [`docs/core-concepts/testing.md`](docs/core-concepts/testing.md) for the full reference.

--- a/docs/core-concepts/readme.md
+++ b/docs/core-concepts/readme.md
@@ -25,6 +25,10 @@ The conceptual tour of the framework. Read these in order if you're new to Tiny.
 8. **[Models](models.md)** — `TinyModel`, schema validation, caching patterns.
 9. **[Database](database.md)** — raw-SQL helpers for MySQL, PostgreSQL, SQLite.
 
+## Testing
+
+10. **[Testing](testing.md)** — built-in zero-ceremony test harness, `tiny::swap()`, `tiny::test()`, `TinyTestResponse`, `:memory:` SQLite.
+
 ## See also
 
 - [Extensions](../extensions/readme.md) — first-party modules (cache, CSRF, SSE, scheduler, CMS, ClickHouse, …)

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -1,0 +1,261 @@
+[Home](../readme.md) | [Getting Started](../getting-started) | [Core Concepts](../core-concepts) | [Helpers](../helpers) | [Extensions](../extensions) | [Repo](https://github.com/ranaroussi/tiny)
+
+# Testing
+
+Tiny ships with a built-in, zero-ceremony testing harness. No PHPUnit XML, no bootstrap scripts, no mock libraries — just PHP files you run from the command line.
+
+## Philosophy
+
+Tiny's testing approach mirrors the framework itself: **let PHP be PHP**. There is no test runner to configure, no container to bootstrap, and no framework-specific assertion library to learn. You write plain PHP scripts that instantiate controllers, call methods, and inspect the response object. This means:
+
+- **Zero startup cost** — a test file is just a PHP script
+- **No dependencies** — you do not need PHPUnit, Pest, or any other test framework
+- **Full framework state** — tests run inside the real framework, not a stripped-down simulation
+
+## Three test-friendly primitives
+
+### 1. `tiny::swap()` — inject mock singletons
+
+Replace the framework's internal singletons with your own objects. Only works when `ENV=test`.
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+class FakeDB extends DB
+{
+    public array $queries = [];
+
+    public function get(string $table, ?string $where = null, string $columns = '*', ?string $order = null, ?int $limit = null): array
+    {
+        $this->queries[] = "SELECT $columns FROM $table";
+        return [['id' => 1, 'name' => 'Test User']];
+    }
+}
+
+$fake = new FakeDB();
+tiny::swap('db', $fake);
+```
+
+Supported names: `db`, `cache`, `clickhouse`.
+
+### 2. `tiny::test()` — load a controller
+
+Returns a controller instance without needing an HTTP request. Only works when `ENV=test`.
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+$ctrl = tiny::test('users');
+
+// Now call any public method directly
+$ctrl->get(tiny::request(), tiny::response());
+```
+
+When `tiny::test()` is called:
+
+- `tiny::request()` returns a fresh `TinyRequest` instance
+- `tiny::response()` returns a `TinyTestResponse` instance that captures instead of terminating
+
+### 3. `TinyTestResponse` — capture instead of terminate
+
+A drop-in replacement for `TinyResponse` used during tests. It records what the controller tried to do without actually sending headers or killing the script.
+
+**Captured properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `$response->redirectUrl` | `?string` | URL passed to `redirect()` |
+| `$response->renderedView` | `?string` | View path passed to `render()` |
+| `$response->renderParams` | `array` | Params passed to `render()` |
+| `$response->output` | `?string` | Output captured from `send()`, `sendJSON()`, `sendFile()`, or `flush()` |
+| `$response->status` | `int` | HTTP status code |
+| `$response->contentType` | `?string` | Content-Type header value |
+
+All response methods that normally terminate (`render`, `redirect`, `send`, `sendJSON`, `sendFile`, `hasCSRFError`) throw `TinyTestExit` when called on a `TinyTestResponse`. Catch it to inspect the captured state.
+
+## Auto `:memory:` SQLite
+
+When `ENV=test`, `DB_TYPE=sqlite`, and `DB_SQLITE_FILE` is empty, Tiny automatically connects to an in-memory SQLite database (`:memory:`). This gives you a fresh, isolated database for every test run without any configuration.
+
+```env
+# .env.test
+ENV=test
+DB_TYPE=sqlite
+```
+
+No `DB_SQLITE_FILE` needed — Tiny handles it.
+
+## Complete example: testing a POST endpoint
+
+`tests/users/create.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+// --- Setup fresh database ---
+tiny::db()->execute("CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE
+)");
+
+// --- Simulate a POST request ---
+$_POST = ['name' => 'Ran', 'email' => 'ran@example.com'];
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+// --- Load controller ---
+$ctrl = tiny::test('users');
+$response = tiny::response(); // TinyTestResponse
+
+try {
+    $ctrl->post(tiny::request(), $response);
+} catch (TinyTestExit $e) {
+    // Expected — redirects and renders throw in test mode
+}
+
+// --- Assert ---
+assert($response->redirectUrl === '/users', 'Should redirect to /users');
+
+$user = tiny::db()->getOne('users', "email = 'ran@example.com'");
+assert($user['name'] === 'Ran', 'User should be inserted');
+
+echo "PASS: users/create\n";
+```
+
+Run it:
+
+```bash
+php tests/users/create.php
+```
+
+If all assertions pass, you see `PASS: users/create`. If an assertion fails, PHP stops and tells you which line failed.
+
+## Testing with a mock database
+
+For unit-style isolation, swap the real DB with a fake:
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+class FakeUserDB extends DB
+{
+    public array $inserted = [];
+    public array $users = [];
+
+    public function insert(string $table, array $data): mixed
+    {
+        $this->inserted[] = compact('table', 'data');
+        return 1;
+    }
+
+    public function get(string $table, ?string $where = null, ...): array
+    {
+        return $this->users;
+    }
+}
+
+$fake = new FakeUserDB();
+tiny::swap('db', $fake);
+
+$ctrl = tiny::test('users');
+$response = tiny::response();
+
+$_POST = ['name' => 'Ran'];
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+try {
+    $ctrl->post(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->redirectUrl === '/users');
+assert($fake->inserted[0]['table'] === 'users');
+assert($fake->inserted[0]['data']['name'] === 'Ran');
+
+echo "PASS\n";
+```
+
+## Testing GET endpoints that render views
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+$ctrl = tiny::test('users');
+$response = tiny::response();
+
+try {
+    $ctrl->get(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->renderedView === 'users/index');
+assert(is_array($response->renderParams['users']));
+
+echo "PASS\n";
+```
+
+## Testing JSON APIs
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+$ctrl = tiny::test('api/users');
+$response = tiny::response();
+
+try {
+    $ctrl->get(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->status === 200);
+assert($response->contentType === 'application/json');
+
+$json = json_decode($response->output, true);
+assert(is_array($json['users']));
+
+echo "PASS\n";
+```
+
+## TestResult helper
+
+Tiny also provides a `TestResult` convenience class with assertion helpers. You can use it to wrap a `TinyTestResponse` for cleaner assertions:
+
+```php
+$result = new TestResult();
+$result->redirect = $response->redirectUrl;
+$result->status = $response->status;
+
+assert($result->isRedirect());
+assert($result->ok());
+```
+
+## Best practices
+
+1. **One test file per controller action** — keeps tests focused and easy to run in isolation.
+2. **Use `:memory:` SQLite for integration tests** — zero configuration, full database coverage.
+3. **Use `tiny::swap('db', ...)` for unit tests** — faster, no database needed.
+4. **Always catch `TinyTestExit`** — it is thrown by every terminating response method in test mode.
+5. **Set `$_SERVER['ENV'] = 'test'` before requiring `tiny.php`** — the framework locks the environment on first load.
+6. **Clean `$_POST` / `$_GET` between tests** — reset request globals at the top of each test file.
+7. **Run tests individually or with a shell loop** — there is no test runner; use `find tests/ -name '*.php' -exec php {} \;` or a simple bash script.

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -12,37 +12,21 @@ Tiny's testing approach mirrors the framework itself: **let PHP be PHP**. There 
 - **No dependencies** — you do not need PHPUnit, Pest, or any other test framework
 - **Full framework state** — tests run inside the real framework, not a stripped-down simulation
 
-## Three test-friendly primitives
+## Setup: create `.env.test`
 
-### 1. `tiny::swap()` — inject mock singletons
+Tests run with `ENV=test`. Create `.env.test` in your project root — it works exactly like `.env.local` but for the test environment.
 
-Replace the framework's internal singletons with your own objects. Only works when `ENV=test`.
-
-```php
-<?php
-declare(strict_types=1);
-
-$_SERVER['ENV'] = 'test';
-require __DIR__ . '/../../tiny/tiny.php';
-
-class FakeDB extends DB
-{
-    public array $queries = [];
-
-    public function get(string $table, ?string $where = null, string $columns = '*', ?string $order = null, ?int $limit = null): array
-    {
-        $this->queries[] = "SELECT $columns FROM $table";
-        return [['id' => 1, 'name' => 'Test User']];
-    }
-}
-
-$fake = new FakeDB();
-tiny::swap('db', $fake);
+```env
+ENV=test
+DB_TYPE=sqlite
+TINY_CACHE_DISABLED=true
 ```
 
-Supported names: `db`, `cache`, `clickhouse`.
+That's all you need. When `ENV=test` + `DB_TYPE=sqlite` with no explicit `DB_SQLITE_FILE`, Tiny automatically connects to `:memory:` — a fresh in-memory database for every test run. `TINY_CACHE_DISABLED=true` keeps tests deterministic by preventing cache pollution between runs.
 
-### 2. `tiny::test()` — load a controller
+No special test runner, no bootstrap script, no ceremony.
+
+## `tiny::test()` — load a controller
 
 Returns a controller instance without needing an HTTP request. Only works when `ENV=test`.
 
@@ -64,7 +48,7 @@ When `tiny::test()` is called:
 - `tiny::request()` returns a fresh `TinyRequest` instance
 - `tiny::response()` returns a `TinyTestResponse` instance that captures instead of terminating
 
-### 3. `TinyTestResponse` — capture instead of terminate
+## `TinyTestResponse` — capture instead of terminate
 
 A drop-in replacement for `TinyResponse` used during tests. It records what the controller tried to do without actually sending headers or killing the script.
 
@@ -80,18 +64,6 @@ A drop-in replacement for `TinyResponse` used during tests. It records what the 
 | `$response->contentType` | `?string` | Content-Type header value |
 
 All response methods that normally terminate (`render`, `redirect`, `send`, `sendJSON`, `sendFile`, `hasCSRFError`) throw `TinyTestExit` when called on a `TinyTestResponse`. Catch it to inspect the captured state.
-
-## Auto `:memory:` SQLite
-
-When `ENV=test`, `DB_TYPE=sqlite`, and `DB_SQLITE_FILE` is empty, Tiny automatically connects to an in-memory SQLite database (`:memory:`). This gives you a fresh, isolated database for every test run without any configuration.
-
-```env
-# .env.test
-ENV=test
-DB_TYPE=sqlite
-```
-
-No `DB_SQLITE_FILE` needed — Tiny handles it.
 
 ## Complete example: testing a POST endpoint
 
@@ -140,55 +112,7 @@ Run it:
 php tests/users/create.php
 ```
 
-If all assertions pass, you see `PASS: users/create`. If an assertion fails, PHP stops and tells you which line failed.
-
-## Testing with a mock database
-
-For unit-style isolation, swap the real DB with a fake:
-
-```php
-<?php
-declare(strict_types=1);
-
-$_SERVER['ENV'] = 'test';
-require __DIR__ . '/../../tiny/tiny.php';
-
-class FakeUserDB extends DB
-{
-    public array $inserted = [];
-    public array $users = [];
-
-    public function insert(string $table, array $data): mixed
-    {
-        $this->inserted[] = compact('table', 'data');
-        return 1;
-    }
-
-    public function get(string $table, ?string $where = null, ...): array
-    {
-        return $this->users;
-    }
-}
-
-$fake = new FakeUserDB();
-tiny::swap('db', $fake);
-
-$ctrl = tiny::test('users');
-$response = tiny::response();
-
-$_POST = ['name' => 'Ran'];
-$_SERVER['REQUEST_METHOD'] = 'POST';
-
-try {
-    $ctrl->post(tiny::request(), $response);
-} catch (TinyTestExit) {}
-
-assert($response->redirectUrl === '/users');
-assert($fake->inserted[0]['table'] === 'users');
-assert($fake->inserted[0]['data']['name'] === 'Ran');
-
-echo "PASS\n";
-```
+If all assertions pass, you see `PASS: users/create`. If an assertion failed, PHP stops and tells you which line failed.
 
 ## Testing GET endpoints that render views
 
@@ -237,6 +161,55 @@ assert(is_array($json['users']));
 echo "PASS\n";
 ```
 
+## `tiny::swap()` — mock singletons for unit-style tests
+
+Sometimes you want to isolate a controller from the database entirely — for example, when testing error paths or when the real DB is too slow. `tiny::swap()` lets you replace the framework's internal singletons with your own objects. Only works when `ENV=test`.
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+class FakeUserDB extends DB
+{
+    public array $inserted = [];
+
+    public function insert(string $table, array $data): mixed
+    {
+        $this->inserted[] = compact('table', 'data');
+        return 1;
+    }
+
+    public function get(string $table, ?string $where = null, string $columns = '*', ?string $order = null, ?int $limit = null): array
+    {
+        return [['id' => 1, 'name' => 'Test User']];
+    }
+}
+
+$fake = new FakeUserDB();
+tiny::swap('db', $fake);
+
+$ctrl = tiny::test('users');
+$response = tiny::response();
+
+$_POST = ['name' => 'Ran'];
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+try {
+    $ctrl->post(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->redirectUrl === '/users');
+assert($fake->inserted[0]['table'] === 'users');
+assert($fake->inserted[0]['data']['name'] === 'Ran');
+
+echo "PASS\n";
+```
+
+Supported names: `db`, `cache`, `clickhouse`.
+
 ## TestResult helper
 
 Tiny also provides a `TestResult` convenience class with assertion helpers. You can use it to wrap a `TinyTestResponse` for cleaner assertions:
@@ -252,10 +225,11 @@ assert($result->ok());
 
 ## Best practices
 
-1. **One test file per controller action** — keeps tests focused and easy to run in isolation.
-2. **Use `:memory:` SQLite for integration tests** — zero configuration, full database coverage.
-3. **Use `tiny::swap('db', ...)` for unit tests** — faster, no database needed.
-4. **Always catch `TinyTestExit`** — it is thrown by every terminating response method in test mode.
-5. **Set `$_SERVER['ENV'] = 'test'` before requiring `tiny.php`** — the framework locks the environment on first load.
-6. **Clean `$_POST` / `$_GET` between tests** — reset request globals at the top of each test file.
-7. **Run tests individually or with a shell loop** — there is no test runner; use `find tests/ -name '*.php' -exec php {} \;` or a simple bash script.
+1. **Create `.env.test`** — it's the deterministic way to configure the test environment. Always set `TINY_CACHE_DISABLED=true`.
+2. **One test file per controller action** — keeps tests focused and easy to run in isolation.
+3. **Use `:memory:` SQLite** — zero configuration, fresh DB per test run.
+4. **Use `tiny::swap('db', ...)` sparingly** — for unit-style isolation when the real DB is too slow or not relevant.
+5. **Always catch `TinyTestExit`** — it is thrown by every terminating response method in test mode.
+6. **Set `$_SERVER['ENV'] = 'test'` before requiring `tiny.php`** — the framework locks the environment on first load.
+7. **Reset `$_POST` / `$_GET` / `$_SERVER['REQUEST_METHOD']` at the top of each test file** — request globals are shared across a PHP process.
+8. **Run tests individually or with a shell loop** — there is no test runner; use `find tests/ -name '*.php' -exec php {} \;` or a simple bash script.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -47,6 +47,7 @@ This documentation covers everything from a 60-second quickstart through every e
 **Tooling**
 - IP-gated debugger (`dd`, `dump`, `log`, `ddump`)
 - CLI for scaffolding and migrations
+- Built-in zero-ceremony testing harness (`tiny::swap()`, `tiny::test()`, `TinyTestResponse`, auto `:memory:` SQLite)
 
 **Integrations (30+ helpers)**
 - Payments: Stripe, S3-compatible Spaces, invoice PDFs
@@ -61,7 +62,7 @@ This documentation covers everything from a 60-second quickstart through every e
 ## How to read this site
 
 1. **[Getting Started](getting-started/readme.md)** — install, configure, runtime modes, deploy.
-2. **[Core Concepts](core-concepts/readme.md)** — MVC, routing, controllers, request/response, views, models, database, middleware, HTMX.
+2. **[Core Concepts](core-concepts/readme.md)** — MVC, routing, controllers, request/response, views, models, database, middleware, HTMX, testing.
 3. **[Extensions](extensions/readme.md)** — every first-party extension that lives in `tiny/ext/`.
 4. **[Helpers](helpers/readme.md)** — the integration catalog plus how to register custom helpers.
 5. **[Examples](examples/readme.md)** — end-to-end walkthroughs (TODO app, API, chat, file upload, user management).

--- a/ext/testexit.php
+++ b/ext/testexit.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Tiny: PHP Framework
+ * https://github.com/ranaroussi/tiny
+ *
+ * Copyright 2013-2024 Ran Aroussi (@aroussi)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+declare(strict_types=1);
+
+
+/**
+ * Exception thrown when tiny::die() or tiny::exit() is called in test mode.
+ * Prevents script termination during controller tests and allows the caller
+ * to capture the response state instead.
+ */
+class TinyTestExit extends \RuntimeException
+{
+}

--- a/ext/testresponse.php
+++ b/ext/testresponse.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Tiny: PHP Framework
+ * https://github.com/ranaroussi/tiny
+ *
+ * Copyright 2013-2024 Ran Aroussi (@aroussi)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+declare(strict_types=1);
+
+
+/**
+ * A test-double response object that captures output instead of
+ * terminating the script. Returned by tiny::response() when test mode
+ * is active (via tiny::test()).
+ */
+class TinyTestResponse extends TinyResponse
+{
+    public ?string $redirectUrl = null;
+    public ?string $renderedView = null;
+    public array $renderParams = [];
+    public ?string $output = null;
+    public int $status = 200;
+    public ?string $contentType = null;
+
+    public function redirect(?string $goto = null, ?string $header = null): void
+    {
+        $this->redirectUrl = $goto;
+        throw new TinyTestExit("Test redirect captured");
+    }
+
+    public function render(string $file = '', array $params = [], bool $die = true): void
+    {
+        $this->renderedView = $file;
+        $this->renderParams = $params;
+        if ($die) {
+            throw new TinyTestExit("Test render captured");
+        }
+    }
+
+    public function send(mixed $text, int $code = 200, bool $die = true): void
+    {
+        $this->output = is_string($text) ? $text : json_encode($text);
+        $this->status = $code;
+        if ($die) {
+            throw new TinyTestExit("Test send captured");
+        }
+    }
+
+    public function sendJSON(mixed $data, int $code = 200, bool $die = true): void
+    {
+        $this->output = is_string($data) ? $data : json_encode($data);
+        $this->status = $code;
+        $this->contentType = 'application/json';
+        if ($die) {
+            throw new TinyTestExit("Test sendJSON captured");
+        }
+    }
+
+    public function sendFile(string $path, int $code = 200, bool $die = true): void
+    {
+        $this->output = file_get_contents($path) ?: null;
+        $this->status = $code;
+        if ($die) {
+            throw new TinyTestExit("Test sendFile captured");
+        }
+    }
+
+    public function flush(string $string = '', bool $finish_request = true): void
+    {
+        $this->output .= $string;
+    }
+
+    public function hasCSRFError(string $id = 'CSRF-VALIDATION-FAILED', bool $nextPage = false): void
+    {
+        $this->output = "CSRF error: $id";
+        throw new TinyTestExit("Test CSRF error captured");
+    }
+}

--- a/ext/testresult.php
+++ b/ext/testresult.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Tiny: PHP Framework
+ * https://github.com/ranaroussi/tiny
+ *
+ * Copyright 2013-2024 Ran Aroussi (@aroussi)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+declare(strict_types=1);
+
+
+/**
+ * A plain data object returned by tiny::testResult() that captures
+ * the outcome of a controller invocation in test mode.
+ */
+class TestResult
+{
+    public ?string $output = null;
+    public ?string $redirect = null;
+    public ?string $view = null;
+    public array $viewParams = [];
+    public int $status = 200;
+    public ?string $contentType = null;
+    public ?string $error = null;
+    public array $headers = [];
+
+    /**
+     * Returns true if the test result indicates a successful response
+     * (no error and an HTTP status in the 2xx range).
+     */
+    public function ok(): bool
+    {
+        return $this->error === null && $this->status >= 200 && $this->status < 300;
+    }
+
+    /**
+     * Returns true if the response captured a redirect.
+     */
+    public function isRedirect(): bool
+    {
+        return $this->redirect !== null;
+    }
+
+    /**
+     * Returns true if the response rendered a view.
+     */
+    public function isRender(): bool
+    {
+        return $this->view !== null;
+    }
+}

--- a/skills/tiny/SKILL.md
+++ b/skills/tiny/SKILL.md
@@ -586,13 +586,17 @@ Supports GFM extensions: callouts, tabs, cards, columns, toggles, steps. Auto-ca
 
 Tiny has a built-in, zero-ceremony testing harness. Test files are plain PHP scripts — no PHPUnit, no bootstrap scripts, no mock libraries.
 
-### Test-friendly primitives
+### Setup: create `.env.test`
 
-- **`tiny::swap('db', $fake)`** — inject a mock/stub singleton (`db`, `cache`, `clickhouse`) in test env only.
-- **`tiny::test('users')`** — load a controller in test env and return its instance.
-- **`TinyTestResponse`** — capture-only response returned by `tiny::response()` in test mode. Records `redirectUrl`, `renderedView`, `renderParams`, `output`, `status`, `contentType`.
-- **`TinyTestExit`** — exception thrown by terminating response methods (`redirect`, `render`, `send`, etc.) in test mode. Always catch it.
-- **Auto `:memory:` SQLite** — when `ENV=test` + `DB_TYPE=sqlite` with no file, auto-connects to `:memory:`.
+Create `.env.test` in the project root:
+
+```env
+ENV=test
+DB_TYPE=sqlite
+TINY_CACHE_DISABLED=true
+```
+
+When `ENV=test` + `DB_TYPE=sqlite` with no `DB_SQLITE_FILE`, Tiny auto-connects to `:memory:` — a fresh in-memory database for every test run. `TINY_CACHE_DISABLED=true` keeps tests deterministic by preventing cache pollution.
 
 ### Test pattern
 
@@ -603,9 +607,10 @@ declare(strict_types=1);
 $_SERVER['ENV'] = 'test';
 require __DIR__ . '/../../tiny/tiny.php';
 
-// Seed in-memory database
+// Seed fresh :memory: database
 tiny::db()->execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
 
+// Simulate request
 $_POST = ['name' => 'Ran'];
 $_SERVER['REQUEST_METHOD'] = 'POST';
 
@@ -619,25 +624,6 @@ try {
 assert($response->redirectUrl === '/users');
 assert(tiny::db()->getOne('users')['name'] === 'Ran');
 echo "PASS\n";
-```
-
-### Testing with a mock DB
-
-```php
-$_SERVER['ENV'] = 'test';
-require __DIR__ . '/../../tiny/tiny.php';
-
-class FakeDB extends DB
-{
-    public array $inserted = [];
-    public function insert(string $table, array $data): mixed
-    {
-        $this->inserted[] = $data;
-        return 1;
-    }
-}
-
-tiny::swap('db', new FakeDB());
 ```
 
 ### Testing GET / view renders
@@ -670,13 +656,35 @@ $json = json_decode($response->output, true);
 assert(is_array($json['users']));
 ```
 
+### Mocking with `tiny::swap()`
+
+For unit-style isolation, replace singletons with fakes. Only works in test env.
+
+```php
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+class FakeDB extends DB
+{
+    public array $inserted = [];
+    public function insert(string $table, array $data): mixed
+    {
+        $this->inserted[] = $data;
+        return 1;
+    }
+}
+
+tiny::swap('db', new FakeDB());
+```
+
 ### Best practices
 
-1. **Set `$_SERVER['ENV'] = 'test'` before requiring `tiny.php`.**
-2. **Always catch `TinyTestExit`** from terminating response methods.
-3. **Use `:memory:` SQLite for integration tests** — zero config, fresh DB per run.
-4. **Use `tiny::swap('db', ...)` for unit tests** — faster, no database needed.
-5. **Reset `$_POST` / `$_GET` / `$_SERVER['REQUEST_METHOD']` between tests** — globals are shared.
+1. **Create `.env.test`** — it's the deterministic way to configure tests. Always set `TINY_CACHE_DISABLED=true`.
+2. **Set `$_SERVER['ENV'] = 'test'` before requiring `tiny.php`.**
+3. **Always catch `TinyTestExit`** from terminating response methods.
+4. **Use `:memory:` SQLite** — zero config, fresh DB per run.
+5. **Use `tiny::swap('db', ...)` sparingly** — for unit-style isolation when the real DB is too slow or not relevant.
+6. **Reset `$_POST` / `$_GET` / `$_SERVER['REQUEST_METHOD']` between tests** — globals are shared.
 
 ---
 

--- a/skills/tiny/SKILL.md
+++ b/skills/tiny/SKILL.md
@@ -582,6 +582,104 @@ Supports GFM extensions: callouts, tabs, cards, columns, toggles, steps. Auto-ca
 
 ---
 
+## Testing
+
+Tiny has a built-in, zero-ceremony testing harness. Test files are plain PHP scripts — no PHPUnit, no bootstrap scripts, no mock libraries.
+
+### Test-friendly primitives
+
+- **`tiny::swap('db', $fake)`** — inject a mock/stub singleton (`db`, `cache`, `clickhouse`) in test env only.
+- **`tiny::test('users')`** — load a controller in test env and return its instance.
+- **`TinyTestResponse`** — capture-only response returned by `tiny::response()` in test mode. Records `redirectUrl`, `renderedView`, `renderParams`, `output`, `status`, `contentType`.
+- **`TinyTestExit`** — exception thrown by terminating response methods (`redirect`, `render`, `send`, etc.) in test mode. Always catch it.
+- **Auto `:memory:` SQLite** — when `ENV=test` + `DB_TYPE=sqlite` with no file, auto-connects to `:memory:`.
+
+### Test pattern
+
+```php
+<?php
+declare(strict_types=1);
+
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+// Seed in-memory database
+tiny::db()->execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
+
+$_POST = ['name' => 'Ran'];
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+$ctrl = tiny::test('users');
+$response = tiny::response();
+
+try {
+    $ctrl->post(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->redirectUrl === '/users');
+assert(tiny::db()->getOne('users')['name'] === 'Ran');
+echo "PASS\n";
+```
+
+### Testing with a mock DB
+
+```php
+$_SERVER['ENV'] = 'test';
+require __DIR__ . '/../../tiny/tiny.php';
+
+class FakeDB extends DB
+{
+    public array $inserted = [];
+    public function insert(string $table, array $data): mixed
+    {
+        $this->inserted[] = $data;
+        return 1;
+    }
+}
+
+tiny::swap('db', new FakeDB());
+```
+
+### Testing GET / view renders
+
+```php
+$ctrl = tiny::test('users');
+$response = tiny::response();
+
+try {
+    $ctrl->get(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->renderedView === 'users/index');
+assert(is_array($response->renderParams['users']));
+```
+
+### Testing JSON APIs
+
+```php
+$ctrl = tiny::test('api/users');
+$response = tiny::response();
+
+try {
+    $ctrl->get(tiny::request(), $response);
+} catch (TinyTestExit) {}
+
+assert($response->status === 200);
+assert($response->contentType === 'application/json');
+$json = json_decode($response->output, true);
+assert(is_array($json['users']));
+```
+
+### Best practices
+
+1. **Set `$_SERVER['ENV'] = 'test'` before requiring `tiny.php`.**
+2. **Always catch `TinyTestExit`** from terminating response methods.
+3. **Use `:memory:` SQLite for integration tests** — zero config, fresh DB per run.
+4. **Use `tiny::swap('db', ...)` for unit tests** — faster, no database needed.
+5. **Reset `$_POST` / `$_GET` / `$_SERVER['REQUEST_METHOD']` between tests** — globals are shared.
+
+---
+
 ## Anti-Patterns to Avoid
 
 1. **Don't add an ORM.** Use the raw SQL wrapper.

--- a/tiny.php
+++ b/tiny.php
@@ -44,6 +44,7 @@ class tiny
     private static array $instances = [];
     private static array $extensions = [];
     private static array $customHelpers = [];
+    private static bool $testMode = false;
 
     /**
      * Initializes the Tiny framework.
@@ -157,7 +158,9 @@ class tiny
         self::$db = match ($dbType) {
             'mysql', 'pgsql', 'postgresql' => new TinyDB($dbType, $dbConfig),
             'sqlite' => new TinyDB('sqlite', [
-                'db_path'   => $_SERVER['DB_SQLITE_FILE'] ?? self::$config->app_path . '/database.db',
+                'db_path'   => $_SERVER['DB_SQLITE_FILE'] ?? (
+                    ($_SERVER['ENV'] ?? '') === 'test' ? ':memory:' : self::$config->app_path . '/database.db'
+                ),
                 'db_scheme' => $_SERVER['DB_SQLITE_SCHEMA'] ?? null
             ]),
             default => throw new \RuntimeException("Unsupported database type: $dbType"),
@@ -562,6 +565,9 @@ class tiny
      */
     public static function request(): TinyRequest
     {
+        if (self::$testMode) {
+            return new TinyRequest();
+        }
         static $request;
         return $request ??= new TinyRequest();
     }
@@ -573,8 +579,66 @@ class tiny
      */
     public static function response(): TinyResponse
     {
+        if (self::$testMode) {
+            return new TinyTestResponse();
+        }
         static $response;
         return $response ??= new TinyResponse();
+    }
+
+    /**
+     * Swap a framework singleton with a mock/stub in test mode.
+     * Only works when ENV is set to 'test'.
+     *
+     * @param string $name The singleton name: 'db', 'cache', or 'clickhouse'
+     * @param object $instance The replacement instance
+     * @return void
+     * @throws \RuntimeException if not in test env or name is invalid
+     */
+    public static function swap(string $name, object $instance): void
+    {
+        if (($_SERVER['ENV'] ?? '') !== 'test') {
+            throw new \RuntimeException('swap() only works in test env');
+        }
+        match ($name) {
+            'db' => self::$db = $instance,
+            'cache' => self::$cache = $instance,
+            'clickhouse' => self::$clickhouse = $instance,
+            default => throw new \RuntimeException("Cannot swap: $name"),
+        };
+    }
+
+    /**
+     * Load a controller in test mode and return the instance.
+     * Only works when ENV is set to 'test'.
+     *
+     * @param string $controller The controller path (e.g. 'users')
+     * @return object The controller instance
+     * @throws \RuntimeException if not in test env or controller not found
+     */
+    public static function test(string $controller): object
+    {
+        if (($_SERVER['ENV'] ?? '') !== 'test') {
+            throw new \RuntimeException('test() only works in test env');
+        }
+
+        self::$testMode = true;
+
+        $filePath = self::$config->app_path . '/controllers/' . $controller . '.php';
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("Controller not found: $controller");
+        }
+
+        require_once $filePath;
+
+        $class = str_replace([' ', '-', '_', '.'], '', ucwords(str_replace('/', ' ', $controller)));
+        $class = preg_replace('/Index$/', '', $class);
+
+        if (!class_exists($class)) {
+            throw new \RuntimeException("Controller class not found: $class");
+        }
+
+        return new $class();
     }
 
     /**
@@ -831,6 +895,9 @@ class tiny
 
     public static function die(mixed $data = null): void
     {
+        if (self::$testMode) {
+            throw new TinyTestExit($data ?? 'Test exit');
+        }
         if (self::isUsingSwoole()) {
             echo $data;
             throw new ExitException("Stopping coroutine");
@@ -841,6 +908,9 @@ class tiny
 
     public static function exit(?int $code = 0): void
     {
+        if (self::$testMode) {
+            throw new TinyTestExit('Test exit', $code ?? 0);
+        }
         if (self::isUsingSwoole()) {
             throw new ExitException("Stopping coroutine", $code);
         } else {


### PR DESCRIPTION
This PR adds a built-in testing harness that lets you test Tiny controllers without PHPUnit, mock libraries, or bootstrap scripts.

## What's new

- `tiny::swap('db', )` — inject mock/stub singletons in test env
- `tiny::test('users')` — load a controller without HTTP
- `TinyTestResponse` — capture-only response (records redirect, render, output, status)
- `TinyTestExit` — exception thrown in test mode instead of script termination
- Auto `:memory:` SQLite when ENV=test + DB_TYPE=sqlite
- `TestResult` helper with `ok()`, `isRedirect()`, `isRender()` assertions
- Full docs at `docs/core-concepts/testing.md`

## Philosophy

Tiny's testing approach mirrors the framework itself: **let PHP be PHP**. Test files are plain PHP scripts run from the command line. No XML configs, no container bootstraps, no framework-specific assertion libraries.

## Example

```php
<?php
declare(strict_types=1);

$_SERVER['ENV'] = 'test';
require __DIR__ . '/../../tiny/tiny.php';

$ctrl = tiny::test('users');
$response = tiny::response();

try {
    $ctrl->post(tiny::request(), $response);
} catch (TinyTestExit) {}

assert($response->redirectUrl === '/users');
echo "PASS\n";
```

Closes the testing gap identified in recent discussions.